### PR TITLE
[Release] study assistant v0.0.4

### DIFF
--- a/src/commands/notify/problem.ts
+++ b/src/commands/notify/problem.ts
@@ -4,6 +4,8 @@ import { getSheetsClient } from '../../auth/index';
 type ProblemRow = [string, string, string, string, string];
 
 const fetchProblems = async (): Promise<ProblemRow[]> => {
+  const COUNT_PROBLEM = 4;
+
   const sheets = await getSheetsClient();
 
   const res = await sheets.spreadsheets.values.get({
@@ -18,7 +20,7 @@ const fetchProblems = async (): Promise<ProblemRow[]> => {
     .filter((row): row is ProblemRow => row.length === 5)
     .filter(problem => currentDate < new Date(problem[0]))
     .sort((a, b) => a[0].localeCompare(b[0]))
-    .slice(0, 3);
+    .slice(0, COUNT_PROBLEM);
 
   if (processedRows.length === 0) {
     throw new Error('No data found...');
@@ -28,7 +30,8 @@ const fetchProblems = async (): Promise<ProblemRow[]> => {
 };
 
 const formatReplyMessage = (problems: ProblemRow[]): string => {
-  let replyMessage = `[다음주 풀이할 문제]\n\n발표자: ${problems[0][1]}\n\n`;
+  let replyMessage = `[다음주 풀이할 문제]\n\n`;
+
   for (const [_1, _2, name, link, _5] of problems) {
     replyMessage += `- [${name}](${link})\n`;
   }


### PR DESCRIPTION
# 설명, 동기 및 배경
해당 Pull Request의 목적은 `develop/v0.0.4`를 `master` 브랜치에 병합하는 것입니다.

`develop/v0.0.4`에는 아래 요구사항이 반영되어 있습니다.
- 매주 문제 풀이 4개로 변경됨에 따라 문제를 가져오는 로직을 3개에서 4개로 변경
- 문제 갯수를 뜻하는 매직넘버 상수로 관리(COUNT_PROBLEM)
- 매주 정했던 발표자가 없어져 문제 공지 메시지에 `발표자` 제거

# 이번 PR의 대상 브랜치는 무엇인가요?
`developt/v0.0.4`

# 스크린샷:
## 슬래시 명령어
<img width="918" alt="스크린샷 2025-05-30 오전 12 38 53" src="https://github.com/user-attachments/assets/43c2c37c-4607-4c85-8292-80ae9b8274df" />

## `/문제공지` 슬래시 명령어 실행 화면
<img width="640" alt="스크린샷 2025-05-30 오전 12 37 32" src="https://github.com/user-attachments/assets/920795ec-e891-4680-96be-754a4a851a84" />

## 디스코드 봇이 고정한 메시지
<img width="413" alt="스크린샷 2025-05-30 오전 12 37 47" src="https://github.com/user-attachments/assets/ea00a2ef-1b34-4525-82bd-7d90b7d6be0e" />

# 주요 변경 사항이 있는 파일 또는 더 주의 깊게 볼 필요가 있는 내용은 무엇인가요?
- src/commands/notify/problem.ts