### PR TITLE
[Release] study assistant v0.0.5 (문제의 갯수 4개로 고정하던 것을 날짜를 기준으로 불러오도록 수정)

### DIFF
--- a/src/commands/notify/problem.ts
+++ b/src/commands/notify/problem.ts
@@ -4,8 +4,6 @@ import { getSheetsClient } from '../../auth/index';
 type ProblemRow = [string, string, string, string, string];
 
 const fetchProblems = async (): Promise<ProblemRow[]> => {
-  const COUNT_PROBLEM = 4;
-
   const sheets = await getSheetsClient();
 
   const res = await sheets.spreadsheets.values.get({
@@ -18,15 +16,17 @@ const fetchProblems = async (): Promise<ProblemRow[]> => {
   const currentDate = new Date();
   const processedRows: ProblemRow[] = rows
     .filter((row): row is ProblemRow => row.length === 5)
-    .filter(problem => currentDate < new Date(problem[0]))
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .slice(0, COUNT_PROBLEM);
+    .filter(problem => currentDate < new Date(problem[0]));
 
   if (processedRows.length === 0) {
     throw new Error('No data found...');
   }
 
-  return processedRows;
+  const minDate = processedRows.map(problem => problem[0]).sort()[0];
+
+  const nextProblems = processedRows.filter(problem => problem[0] === minDate);
+
+  return nextProblems;
 };
 
 const formatReplyMessage = (problems: ProblemRow[]): string => {


### PR DESCRIPTION
# 설명, 동기 및 배경
해당 Pull Request의 목적은 `develop/v0.0.5`를 `master` 브랜치에 병합하는 것입니다.

## develop/v0.0.5 요구사항
- 매주 문제 풀이 갯수를 4개로 제한했는데 상황에 따라 5개도 될 수 있고 4개가 될 수도 있어 로직을 다음에 풀어야할 문제들 중 가장 최근 날짜를 가진 문제를 가져오도록 변경

# 이번 PR의 대상 브랜치는 무엇인가요?
`develop/v0.0.5`

# 스크린샷:

## `/문제공지` 슬래시 명령어 실행 화면 
<img width="404" alt="스크린샷 2025-06-16 오후 10 06 46" src="https://github.com/user-attachments/assets/aaaa27ad-1f38-4639-8d06-46916dd68a7d" />

# 주요 변경 사항이 있는 파일 또는 더 주의 깊게 볼 필요가 있는 내용
- `src/commands/notify/problem.ts`
